### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,24 @@
+import { internalServerError, MethodNotAllowedError } from "./errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new internalServerError({
+    cause: error,
+    statusCode: error.statusCode,
+  });
+  console.log(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,5 +1,5 @@
 import { Client } from "pg";
-import { internalServerError } from "infra/errors";
+import { ServiceError } from "infra/errors";
 
 async function query(queryObject) {
   let client;
@@ -11,12 +11,11 @@ async function query(queryObject) {
 
     return result;
   } catch (error) {
-    const publicErrorObject = new internalServerError({
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com banco de dados ou validação da query.",
       cause: error,
     });
-
-    console.log("\n erro dentro do catch do database.js");
-    console.error(publicErrorObject);
+    console.error(serviceErrorObject);
 
     throw error;
   } finally {

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,11 @@
 export class internalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Houve um erro interno inesperado:", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
   }
 
   toJSON() {
@@ -18,6 +18,25 @@ export class internalServerError extends Error {
   }
 }
 
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique status dos serviços";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      statusCode: this.statusCode,
+    };
+  }
+}
 export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpont.");

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -17,3 +17,22 @@ export class internalServerError extends Error {
     };
   }
 }
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpont.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      statusCode: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.7",
         "dotenv-expand": "12.0.1",
         "next": "13.1.6",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.8.0",
         "nodejs": "0.0.0",
         "pg": "8.13.1",
@@ -2213,6 +2214,12 @@
       "dependencies": {
         "@textlint/ast-node-types": "^14.4.2"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8059,6 +8066,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9231,6 +9251,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "16.4.7",
     "dotenv-expand": "12.0.1",
     "next": "13.1.6",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.8.0",
     "nodejs": "0.0.0",
     "pg": "8.13.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,50 +1,105 @@
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import { internalServerError, MethodNotAllowedError } from "infra/errors";
 
-export default async function migrations(request, response) {
-  const allowedRequestMethods = ["GET", "POST"];
+const router = createRouter();
 
-  if (!allowedRequestMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}" not allowed`,
-    });
-  }
-  let dbClient;
+router.get(getHandler);
+
+router.post(postHandler);
+
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new internalServerError({
+    cause: error,
+  });
+  console.log("\nErro dentro do catch do controler api/v1/migrations:");
+  console.log(publicErrorObject);
+
+  response.status(500).json(publicErrorObject);
+}
+
+async function postHandler(request, response) {
+  let dbClient, defaultMigrationOptions;
 
   try {
-    dbClient = await database.getNewClient();
+    dbClient = await connectToDatabase();
+    defaultMigrationOptions = await defineMigrationOptions(dbClient);
 
-    const defaultMigrationOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dryRun: false,
+    });
 
-    if (request.method === "GET") {
-      const pendinMigrations = await migrationRunner(defaultMigrationOptions);
-
-      return response.status(200).json(pendinMigrations);
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-      return response.status(200).json(migratedMigrations);
-    }
+    return response.status(200).json(migratedMigrations);
   } catch (error) {
     console.error(error);
     throw error;
   } finally {
-    await dbClient.end();
+    await dbClient?.end();
+  }
+}
+
+async function getHandler(request, response) {
+  if (request.method !== "GET") {
+    console.log(
+      `Method ${request.method} not allowed in getHandler at api/v1/migrations`,
+    );
+
+    const publicErrorObject = new MethodNotAllowedError();
+    return response
+      .status(publicErrorObject.statusCode)
+      .json(publicErrorObject);
+  }
+
+  let dbClient, defaultMigrationOptions;
+
+  try {
+    dbClient = await connectToDatabase();
+    defaultMigrationOptions = await defineMigrationOptions(dbClient);
+
+    const pendinMigrations = await migrationRunner(defaultMigrationOptions);
+
+    return response.status(200).json(pendinMigrations);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+async function defineMigrationOptions(dbClient) {
+  const defaultMigrationOptions = {
+    dbClient: dbClient,
+    dryRun: true,
+    dir: resolve("infra", "migrations"),
+    direction: "up",
+    verbose: true,
+    migrationsTable: "pgmigrations",
+  };
+
+  return defaultMigrationOptions;
+}
+
+async function connectToDatabase() {
+  try {
+    return await database.getNewClient();
+  } catch (error) {
+    throw new internalServerError();
   }
 }

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -3,32 +3,14 @@ import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
 import { internalServerError, MethodNotAllowedError } from "infra/errors";
+import controller from "infra/controller";
 
 const router = createRouter();
 
 router.get(getHandler);
-
 router.post(postHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNoMatchHandler(request, response) {
-  const publicErrorObject = new MethodNotAllowedError();
-  response.status(publicErrorObject.statusCode).json(publicErrorObject);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicErrorObject = new internalServerError({
-    cause: error,
-  });
-  console.log("\nErro dentro do catch do controler api/v1/migrations:");
-  console.log(publicErrorObject);
-
-  response.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 async function postHandler(request, response) {
   let dbClient, defaultMigrationOptions;
@@ -46,9 +28,6 @@ async function postHandler(request, response) {
       return response.status(201).json(migratedMigrations);
     }
     return response.status(200).json(migratedMigrations);
-  } catch (error) {
-    console.error(error);
-    throw error;
   } finally {
     await dbClient?.end();
   }
@@ -56,10 +35,6 @@ async function postHandler(request, response) {
 
 async function getHandler(request, response) {
   if (request.method !== "GET") {
-    console.log(
-      `Method ${request.method} not allowed in getHandler at api/v1/migrations`,
-    );
-
     const publicErrorObject = new MethodNotAllowedError();
     return response
       .status(publicErrorObject.statusCode)
@@ -72,12 +47,12 @@ async function getHandler(request, response) {
     dbClient = await connectToDatabase();
     defaultMigrationOptions = await defineMigrationOptions(dbClient);
 
-    const pendinMigrations = await migrationRunner(defaultMigrationOptions);
+    const pendinMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dryRun: true,
+    });
 
     return response.status(200).json(pendinMigrations);
-  } catch (error) {
-    console.error(error);
-    throw error;
   } finally {
     await dbClient?.end();
   }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,37 +1,16 @@
 import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { internalServerError, MethodNotAllowedError } from "infra/errors";
+import { MethodNotAllowedError } from "infra/errors";
+import controller from "infra/controller";
 
 const router = createRouter();
 
 router.get(getHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNoMatchHandler(request, response) {
-  const publicErrorObject = new MethodNotAllowedError();
-  response.status(publicErrorObject.statusCode).json(publicErrorObject);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicErrorObject = new internalServerError({
-    cause: error,
-  });
-  console.log("\nErro dentro do catch do controler api/v1/status:");
-  console.log(publicErrorObject);
-
-  response.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 async function getHandler(request, response) {
   if (request.method !== "GET") {
-    console.log(
-      `Method ${request.method} not allowed in getHandler at api/v1/migrations`,
-    );
-
     const publicErrorObject = new MethodNotAllowedError();
     return response
       .status(publicErrorObject.statusCode)

--- a/tests/Integration/api/v1/migrations/head.test.js
+++ b/tests/Integration/api/v1/migrations/head.test.js
@@ -7,22 +7,23 @@ describe("HEAD/DELETE/PUT /api/v1/migrations", () => {
           method: "HEAD",
         },
       );
+      expect(responseToHead.status).toEqual(405);
+
       const responseToDelete = await fetch(
         "http://127.0.0.1:3000/api/v1/migrations",
         {
           method: "DELETE",
         },
       );
+      expect(responseToDelete.status).toEqual(405);
+
       const responseToPut = await fetch(
         "http://127.0.0.1:3000/api/v1/migrations",
         {
           method: "PUT",
         },
       );
-
-      expect(responseToHead.status).toBe(405);
-      expect(responseToDelete.status).toBe(405);
-      expect(responseToPut.status).toBe(405);
+      expect(responseToPut.status).toEqual(405);
     });
   });
 });

--- a/tests/Integration/api/v1/status/post.test.js
+++ b/tests/Integration/api/v1/status/post.test.js
@@ -1,0 +1,37 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Aonymous user", () => {
+    test("trying to access status with not allowed methods", async () => {
+      const responseToPost = await fetch(
+        "http://127.0.0.1:3000/api/v1/status",
+        {
+          method: `POST`,
+        },
+      );
+      expect(responseToPost.status).toBe(405);
+
+      const responseToPostBody = await responseToPost.json();
+
+      expect(responseToPostBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpont.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        statusCode: 405,
+      });
+
+      const responseToHead = await fetch(
+        "http://127.0.0.1:3000/api/v1/status",
+        {
+          method: `HEAD`,
+        },
+      );
+      expect(responseToHead.status).toBe(405);
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -21,7 +21,7 @@ async function waitForAllServices() {
 }
 
 async function clearDatabase() {
-  database.query("drop schema public cascade; create schema public;");
+  await database.query("drop schema public cascade; create schema public;");
 }
 
 const orchestrator = {


### PR DESCRIPTION
1. Padroniza controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`.
3. Melhora o `internalServerError` de forma que o `statusCode` possa ser personalizado quando criado.